### PR TITLE
Improved Performance

### DIFF
--- a/public/js/drawMap.js
+++ b/public/js/drawMap.js
@@ -92,13 +92,13 @@ var scene = {
 
                 //  if(s_x > $('#background').width() || s_y > $('#background').height()){return;} //outside current window, don't load
 
-                scratchCanvas.drawImage(scene.tileSets[tileSetIndex], img_x, img_y, size, size, s_x, s_y, size, size);
+                scratchCanvas.drawSafeImage(scene.tileSets[tileSetIndex], img_x, img_y, size, size, s_x, s_y, size, size);
 
             });
 
             //scene.layers.push(scratchCanvas.canvas.toDataURL()); //save scratch canvas for later
             scene.layers.push(scratchCanvas.canvas);
-            scene.context.drawImage(scratchCanvas.canvas, -backgroundOffset.x, -backgroundOffset.y, $('#background').width() / scene.zoom, $('#background').height() / scene.zoom, 0, 0, $('#background').width(), $('#background').height()); //draw image from scratch canvas for better performance
+            scene.context.drawSafeImage(scratchCanvas.canvas, -backgroundOffset.x, -backgroundOffset.y, $('#background').width() / scene.zoom, $('#background').height() / scene.zoom, 0, 0, $('#background').width(), $('#background').height()); //draw image from scratch canvas for better performance
 
         } else { //if all the layers have been previously loaded, use the cache
 
@@ -109,7 +109,7 @@ var scene = {
                 (layer.height + backgroundOffset.y) / scene.zoom < $('#background').height() ? backgroundOffset.y = $('#background').height() * scene.zoom - layer.height : backgroundOffset.y;
                 //var i = $("<img />", {src: src})[0];
                 // //console.log(layer);
-                scene.context.drawImage(layer, -backgroundOffset.x, -backgroundOffset.y, $('#background').width() * scene.zoom, $('#background').height() * scene.zoom, 0, 0, $('#background').width(), $('#background').height()); //draw image from scratch canvas for better performance
+                scene.context.drawSafeImage(layer, -backgroundOffset.x, -backgroundOffset.y, $('#background').width() * scene.zoom, $('#background').height() * scene.zoom, 0, 0, $('#background').width(), $('#background').height()); //draw image from scratch canvas for better performance
             });
         }
     },
@@ -220,7 +220,7 @@ function drawEntities(entities, ctx, lock, clear) {
           cutOutCharacter(newCan, characterImages[entities[entity].type], img_x, img_y, entities[entity].size, entities[entity].size);
 
         // scaleDown(newCan, 32, 32);
-          ctx.drawImage(newCan, 0, 0, 150, 150,  x * zoom + backgroundOffset.x * zoom, y * zoom + backgroundOffset.y * zoom, 32 * zoom, 32 * zoom);
+          ctx.drawSafeImage(newCan, 0, 0, 150, 150,  x * zoom + backgroundOffset.x * zoom, y * zoom + backgroundOffset.y * zoom, 32 * zoom, 32 * zoom);
          //ctx.drawImage(newCan, 300, 200);
         //  ctx.drawImage(newCan, 0, 0, 32, 32,  x - backgroundOffset.x, y - backgroundOffset.y, 32, 32);  //This is going from 150 to 32
 
@@ -246,7 +246,7 @@ function cutOutCharacter(newCan, img, x, y, width, height){
 	newCan.width = width;
 	newCan.height = height;
 	var ctx = newCan.getContext('2d');
-	ctx.drawImage(img, x, y, width, height, 0, 0, width, height);
+	ctx.drawSafeImage(img, x, y, width, height, 0, 0, width, height);
 	return newCan;
 	
 	
@@ -269,13 +269,13 @@ function scaleDown(justCharacter, height, width){
 		oldWidth /= 2;
 		oldHeight /= 2;
 		//ctx.clearRect(0, 0, scalingCanvas.width, scalingCanvas.height);
-		ctx.drawImage(scalingCanvas, 0, 0, oldWidth, oldHeight, 0, 0, oldWidth/2, oldHeight/2);
+		ctx.drawSafeImage(scalingCanvas, 0, 0, oldWidth, oldHeight, 0, 0, oldWidth/2, oldHeight/2);
 	}
 	justCharacter.height = height;
 	justCharacter.width = width;
 	var finalCtx = justCharacter.getContext('2d');
 	finalCtx.clearRect(0, 0, justCharacter.width, justCharacter.height);
-	finalCtx.drawImage(scalingCanvas, 0, 0, oldWidth, oldHeight, 0, 0, width, height);
+	finalCtx.drawSafeImage(scalingCanvas, 0, 0, oldWidth, oldHeight, 0, 0, width, height);
 }
 
 

--- a/public/js/drawMap.js
+++ b/public/js/drawMap.js
@@ -98,18 +98,18 @@ var scene = {
 
             //scene.layers.push(scratchCanvas.canvas.toDataURL()); //save scratch canvas for later
             scene.layers.push(scratchCanvas.canvas);
-            scene.context.drawImage(scratchCanvas.canvas, -backgroundOffset.x, -backgroundOffset.y, $('#background').width() / scene.zoom, $('#background').height() / scene.zoom, 0, 0, $('#background').width(), $('#background').height()); //draw image from scratch canvas for better performance
+            scene.context.drawImage(scratchCanvas.canvas, -backgroundOffset.x, -backgroundOffset.y, canvasWidth / scene.zoom, canvasHeight / scene.zoom, 0, 0, canvasWidth, canvasHeight); //draw image from scratch canvas for better performance
 
         } else { //if all the layers have been previously loaded, use the cache
 
             scene.layers.forEach(function(layer) {
                 backgroundOffset.x > 0 ? backgroundOffset.x = 0 : backgroundOffset.x; //Make sure not to pan outside of map
                 backgroundOffset.y > 0 ? backgroundOffset.y = 0 : backgroundOffset.y;
-                (layer.width + backgroundOffset.x) / scene.zoom < $('#background').width() ? backgroundOffset.x = $('#background').width() * scene.zoom - layer.width : backgroundOffset.x;
-                (layer.height + backgroundOffset.y) / scene.zoom < $('#background').height() ? backgroundOffset.y = $('#background').height() * scene.zoom - layer.height : backgroundOffset.y;
+                (layer.width + backgroundOffset.x) / scene.zoom < canvasWidth ? backgroundOffset.x = canvasWidth * scene.zoom - layer.width : backgroundOffset.x;
+                (layer.height + backgroundOffset.y) / scene.zoom < canvasHeight ? backgroundOffset.y = canvasHeight * scene.zoom - layer.height : backgroundOffset.y;
                 //var i = $("<img />", {src: src})[0];
                 // //console.log(layer);
-                scene.context.drawSafeImage(layer, -backgroundOffset.x, -backgroundOffset.y, $('#background').width() * scene.zoom, $('#background').height() * scene.zoom, 0, 0, $('#background').width(), $('#background').height()); //draw image from scratch canvas for better performance
+                scene.context.drawSafeImage(layer, -backgroundOffset.x, -backgroundOffset.y, canvasWidth * scene.zoom, canvasHeight * scene.zoom, 0, 0, canvasWidth, canvasHeight); //draw image from scratch canvas for better performance
             });
         }
     },

--- a/public/js/drawMap.js
+++ b/public/js/drawMap.js
@@ -92,13 +92,13 @@ var scene = {
 
                 //  if(s_x > $('#background').width() || s_y > $('#background').height()){return;} //outside current window, don't load
 
-                scratchCanvas.drawSafeImage(scene.tileSets[tileSetIndex], img_x, img_y, size, size, s_x, s_y, size, size);
+                scratchCanvas.drawImage(scene.tileSets[tileSetIndex], img_x, img_y, size, size, s_x, s_y, size, size);
 
             });
 
             //scene.layers.push(scratchCanvas.canvas.toDataURL()); //save scratch canvas for later
             scene.layers.push(scratchCanvas.canvas);
-            scene.context.drawSafeImage(scratchCanvas.canvas, -backgroundOffset.x, -backgroundOffset.y, $('#background').width() / scene.zoom, $('#background').height() / scene.zoom, 0, 0, $('#background').width(), $('#background').height()); //draw image from scratch canvas for better performance
+            scene.context.drawImage(scratchCanvas.canvas, -backgroundOffset.x, -backgroundOffset.y, $('#background').width() / scene.zoom, $('#background').height() / scene.zoom, 0, 0, $('#background').width(), $('#background').height()); //draw image from scratch canvas for better performance
 
         } else { //if all the layers have been previously loaded, use the cache
 

--- a/public/js/globals.js
+++ b/public/js/globals.js
@@ -36,7 +36,7 @@ var size = 32;  //Get rid of this magic number
 var socket;
 var useMin = true; //use minimized images
 var wasCtrl = false;
-var zoom = 1; //starting zoom of map
+var zoom = 3; //starting zoom of map
 var zoomHappened = false;
 var canvasWidth; 
 var canvasHeight;

--- a/public/js/globals.js
+++ b/public/js/globals.js
@@ -36,7 +36,7 @@ var size = 32;  //Get rid of this magic number
 var socket;
 var useMin = true; //use minimized images
 var wasCtrl = false;
-var zoom = 3; //starting zoom of map
+var zoom = 1; //starting zoom of map
 var zoomHappened = false;
 var canvasWidth; 
 var canvasHeight;

--- a/public/js/globals.js
+++ b/public/js/globals.js
@@ -55,6 +55,6 @@ CanvasRenderingContext2D.prototype.drawSafeImage = function(image, sx, sy, sWidt
     canvasWidth = $('#background').width();
     canvasHeight = $('#background').height();
   }
-  if (dx  < canvasWidth && dy < canvasHeight && dx > 0 && dy  > 0)
+  if (dx  < canvasWidth && dy < canvasHeight && dx >= 0 && dy >= 0)
         this.drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
 }

--- a/public/js/globals.js
+++ b/public/js/globals.js
@@ -55,6 +55,6 @@ CanvasRenderingContext2D.prototype.drawSafeImage = function(image, sx, sy, sWidt
     canvasWidth = $('#background').width();
     canvasHeight = $('#background').height();
   }
-  if (dx  < canvasWidth && dy < canvasHeight && dx + dWidth > 0 && dy + dHeight > 0)
+  if (dx  < canvasWidth && dy < canvasHeight && dx > 0 && dy  > 0)
         this.drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
 }


### PR DESCRIPTION
Now use safeDrawImage to check to make sure that entities are not drawn if they are outside the window.  Levels load like this: 
1.  The entire map is draw
2.  A section of the map is cut and draw on the screen

This seems to be great for performance,  we'll stick with this until there is a problem.  If the map is gigantic, initial loading could be a problem, or the map may not be able to fit in memory.  Then we could just split the map into subsections an load them when the window is near them.
